### PR TITLE
Upload to GCS, incorporate gflags for imgproc flag parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*__pycache__/
+*.pyc

--- a/src/imgproc/cpp/Makefile
+++ b/src/imgproc/cpp/Makefile
@@ -1,5 +1,5 @@
 
-LIBS = -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
+LIBS = -lgflags_nothreads -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
 
 all: pipeline
 

--- a/src/imgproc/cpp/README.md
+++ b/src/imgproc/cpp/README.md
@@ -1,6 +1,6 @@
 **Under development image processing code**
 
-*Requires OpenCV 3*
+*Requires OpenCV 3 and [GFlags](https://github.com/gflags/gflags)*
 
 **Parameters:** 
 - images_file: text file of image filenames with no path prefix, one per line 

--- a/src/imgproc/cpp/README.md
+++ b/src/imgproc/cpp/README.md
@@ -30,12 +30,6 @@ To build/run:
 $ # Build
 $ make
 $
-$ # Run
-$ ./imgproc
-Example usage:
-    $ ./pipeline --images_file=/path/to.file --mode=$MODE --output_dir=/path/to/dir --hough_dp=2.0
-
-Params:
-    output_dir required when run in batch mode
-    modes: window, batch
+$ # Example usage
+$ ./pipeline --images_file=/path/to.file --mode=$MODE --output_dir=/path/to/dir --hough_dp=2.0
 ```

--- a/src/imgproc/cpp/README.md
+++ b/src/imgproc/cpp/README.md
@@ -6,6 +6,11 @@
 - images_file: text file of image filenames with no path prefix, one per line 
 - mode: batch or window (see below).
 - output_dir: directory to save image processed image and metadata files 
+- hough transform parameters
+  - hough_dp (double)
+  - hough_param1 (double)
+  - hough_param2 (double)
+  - hough_min_dist (double)
 
 **Modes:**
 - `batch` mode: this will loop through all the images without stopping, 
@@ -27,8 +32,8 @@ $ make
 $
 $ # Run
 $ ./imgproc
-Usage:
-    $ ./pipeline images_file mode [output_dir]
+Example usage:
+    $ ./pipeline --images_file=/path/to.file --mode=$MODE --output_dir=/path/to/dir --hough_dp=2.0
 
 Params:
     output_dir required when run in batch mode

--- a/src/imgproc/cpp/imgproc_defs.h
+++ b/src/imgproc/cpp/imgproc_defs.h
@@ -1,17 +1,32 @@
 #ifndef _IMGPROC_DEFS_H
 #define _IMGPROC_DEFS_H
 
+
 #define METADATA_SEP        "|"
 #define ESC_KEY             1048603
 #define HD_MAX_W            1920
 #define HD_MAX_H            1080
 #define METADATA_FILE_NAME  "metadata.txt"
 #define MIN_SUN_RADIUS      50
+#define DEFAULT_IMG_EXT     ".jpg"
+
 
 enum ImgprocMode 
 {
     BATCH = 0,
     WINDOW,
 };
+
+
+static const char *SUPPORTED_IMG_EXT[6] = {
+    ".png",
+    ".PNG",
+    ".jpg",
+    ".JPG",
+    ".jpeg",
+    ".JPEG"
+};
+
+static const unsigned NUM_SUPPORTED_IMG_EXT = 6;
 
 #endif

--- a/src/imgproc/cpp/imgproc_image.cc
+++ b/src/imgproc/cpp/imgproc_image.cc
@@ -17,6 +17,25 @@ ImgProcImage::ImgProcImage()
 ImgProcImage::ImgProcImage(const cv::Mat &image, ImgprocMode mode, std::ofstream *metadata_file, const string &image_dest)
 : original(image), mode(mode), metadata_file(metadata_file), dest(image_dest)
 {
+    // imwrite requires filenames to end with an image file extension in order to know what 
+    // type of image file to create
+    if (this->mode != BATCH)
+    {
+        return;
+    }
+
+    bool dest_ends_with_valid_ext = false;
+
+    for (int i = 0; i < NUM_SUPPORTED_IMG_EXT; i++)
+    {
+        size_t pos = this->dest.rfind(SUPPORTED_IMG_EXT[i]);
+        dest_ends_with_valid_ext |= (pos == (this->dest.size() - strlen(SUPPORTED_IMG_EXT[i])));
+    }
+
+    if (!dest_ends_with_valid_ext)
+    {
+        this->dest += DEFAULT_IMG_EXT;
+    }
 }
 
 cv::Mat &ImgProcImage::get_original_image()

--- a/src/imgproc/cpp/imgproc_pipeline_base.h
+++ b/src/imgproc/cpp/imgproc_pipeline_base.h
@@ -23,6 +23,18 @@ private:
 protected:
     ImgProcImage current_image;
 
+    // cv::HoughCircles dp parameter
+    double hough_dp;
+
+    // cv::HoughCircles param1 parameter
+    double hough_param1;
+
+    // cv::HoughCircles param2 parameter
+    double hough_param2;
+
+    // cv::HoughCircles min_dist parameter
+    double hough_min_dist;
+
 public:
     // Will open up the initialize image_file ifstream object given input_file string
     ImgProcPipelineBase(int, char **);        

--- a/src/imgproc/cpp/imgproc_pipeline_base.h
+++ b/src/imgproc/cpp/imgproc_pipeline_base.h
@@ -35,6 +35,12 @@ protected:
     // cv::HoughCircles min_dist parameter
     double hough_min_dist;
 
+    // cv::HoughCircles min_radius parameter
+    int hough_min_radius;
+
+    // cv::HoughCircles max_radius parameter
+    int hough_max_radius;
+
 public:
     // Will open up the initialize image_file ifstream object given input_file string
     ImgProcPipelineBase(int, char **);        

--- a/tools/run_imgproc_test/README.md
+++ b/tools/run_imgproc_test/README.md
@@ -13,14 +13,20 @@ Requirements:
 To run the tool:
 
 ```bash
-$ ./test DIR [download]
+$ ./test $DIR $GCS_BUCKET [download] [$PIPELINE_FLAGS]
+$
+$ # $PIPELINE_FLAGS should be of the form "--flag1=value --flag2=othervalue"
 ```
- `DIR` is the directory to use for image/data storage. The following will be saved into `DIR`:
- 
- - ***If `download` flag set***: A clone of the GCS bucket `eclipse_image_ground_truth_dataset_renamed`
- - A directory called `output` that will contain:
-   - All the processed images with sun/moon circles overlayed from the `eclipse_image_ground_truth_dataset_renamed` bucket
-   - A file called `metadata.txt` that will contain the processed image names along with output information from the image processor
-   - A file called `output.html` that includes summarizes the image processor output info.
 
-The `output.html` file will be automatically opened with Google Chrome
+- `$DIR` is the directory to use for image/data storage. The following will be saved into `DIR`:
+   - ***If `download` flag set***: A clone of the `$GCS_BUCKET`
+     - A directory called `output` that will contain:
+       - All the processed images `$GCS_BUCKET`
+       - A metadata file that will contain the processed image names along with output information from the image processor
+       - An HTML file that includes summarizes the image processor output info.
+- `$GCS_BUCKET` is the Google Cloud Storage bucket holding the images to process. All the images in this bucket will
+be processed
+- `$PIPELINE_FLAGS` is a single argument containing the flags that should be passed to the image processor pipeline
+
+The output HTML file will be automatically uploaded to Google Cloud Storage. The URL to access this page 
+will be printed to the console.

--- a/tools/run_imgproc_test/README.md
+++ b/tools/run_imgproc_test/README.md
@@ -1,5 +1,5 @@
 This tool will run the image processor and summarize the results in an HTML file. This script 
-will take care of downloading the images from Google Cloud Storage (if the `download` flag is set, 
+will take care of downloading the images from Google Cloud Storage (if the `download` flag is set), 
 and building the image processor. This tool assumes access to the `northamericaneclipseimages` 
 Google Cloud Project.
 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -45,6 +45,12 @@ HTML = """
 
 <script>
 
+    var COLUMN_CHOICES = {
+        SUN : 2,
+        MOON : 3,
+        TIMES : 4
+    };
+
     var prev_col_name = " ";
     var ascending = true;
     
@@ -168,15 +174,15 @@ HTML = """
         var start = performance.now();
 
         switch(n) {
-            case 2:
+            case COLUMN_CHOICES.SUN:
                 var col_name = "sun_diff";
                 row_array.sort(sun_diff_comparator);
                 break;
-            case 3:
+            case COLUMN_CHOICES.MOON:
                 var col_name = "moon_diff";
                 row_array.sort(moon_diff_comparator);
                 break;
-            case 4:
+            case COLUMN_CHOICES.TIMES:
                 var col_name = "times";
                 row_array.sort(times_comparator);
                 break;
@@ -248,17 +254,17 @@ HTML = """
 		                        Processed
 	                        </th>
 
-	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(2)" style="cursor: pointer;">
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(COLUMN_CHOICES.SUN)" style="cursor: pointer;">
 		                        Sun Results
                                 <i id="sun_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="sun_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
-	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(3)" style="cursor: pointer;">
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(COLUMN_CHOICES.MOON)" style="cursor: pointer;">
 		                        Moon Results
                                 <i id="moon_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="moon_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
-	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(4)" style="cursor: pointer;">
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(COLUMN_CHOICES.TIMES)" style="cursor: pointer;">
 		                        Running times (secs)
                                 <i id="times_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="times_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -438,18 +438,29 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
             
         if truth_file is not None:
         
-            if truth_positions[img_name]['moon'] is not None:
-                moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
-                item['moon_center_diff'] = moon_center_offset
-                item['moon_rad_diff'] = moon_radius_diff
-            else:
-                item['moon_center_diff'] = "No Moon in ground truth"
-                item['moon_rad_diff'] = "No Moon in ground truth"
+            try:
+                if truth_positions[img_name]['moon'] is not None:
+                    moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
+                    item['moon_center_diff'] = moon_center_offset
+                    item['moon_rad_diff'] = moon_radius_diff
+                else:
+                    item['moon_center_diff'] = "No Moon in ground truth"
+                    item['moon_rad_diff'] = "No Moon in ground truth"
 
-            sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
+                sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
 
-            item['sun_center_diff'] = sun_center_offset
-            item['sun_rad_diff'] = sun_radius_diff
+                item['sun_center_diff'] = sun_center_offset
+                item['sun_rad_diff'] = sun_radius_diff
+                
+                if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
+                    pos_sum += (sun_center_offset + sun_radius_diff)
+                    pos_count += 1
+                if tokens[2] is not None and truth_positions[img_name]['moon'] is not None:
+                    pos_sum += (moon_center_offset + moon_radius_diff)
+                    pos_count += 1
+                
+            except KeyError:
+                pass
             
         else:
             item['moon_center_diff'] = "No ground truth"
@@ -457,13 +468,6 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
             
             item['sun_center_diff'] = "No ground truth"
             item['sun_rad_diff'] = "No ground truth"
-            
-        if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
-            pos_sum += (sun_center_offset + sun_radius_diff)
-            pos_count += 1
-        if tokens[2] is not None and truth_positions[img_name]['moon'] is not None:
-            pos_sum += (moon_center_offset + moon_radius_diff)
-            pos_count += 1
 
         metadata_items.append(item)
     

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -475,7 +475,7 @@ def main():
     html_path = build_html_doc(original_dir, processed_dir, original_bucket, processed_bucket, converter)
     html_path = converter.get_run_specific_filename(html_path)
 
-    #converter.commit(processed_dir)
+    converter.commit(processed_dir)
 
     print('WEB_URL:{}'.format(util.gcs_url(html_path, processed_bucket)))
 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -426,12 +426,12 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         item['comments'] = comments
         item['circles'] = circles
         
-        if tokens[1] is not None:
+        if tokens[1].startswith('c'):
             item['found_sun'] = literal_eval(tokens[1][1:])
         else:
             item['found_sun'] = "undefined"
             
-        if tokens[2] is not None:
+        if tokens[2].startswith('c'):
             item['found_moon'] = literal_eval(tokens[2][1:])
         else:
             item['found_sun'] = "undefined"
@@ -439,25 +439,33 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         if truth_file is not None and img_name in truth_positions:
  
             if truth_positions[img_name]['moon'] is not None:
-                moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
-                item['moon_center_diff'] = moon_center_offset
-                item['moon_rad_diff'] = moon_radius_diff
+                if tokens[2].startswith('c'):
+                    moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
+                    item['moon_center_diff'] = moon_center_offset
+                    item['moon_rad_diff'] = moon_radius_diff
+                else:
+                    item['moon_center_diff'] = "undefined"
+                    item['moon_rad_diff'] = "undefined"
             else:
                 item['moon_center_diff'] = "No Moon in ground truth"
                 item['moon_rad_diff'] = "No Moon in ground truth"
 
             if truth_positions[img_name]['sun'] is not None:
-                sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
-                item['sun_center_diff'] = sun_center_offset
-                item['sun_rad_diff'] = sun_radius_diff
+                if tokens[1].startswith('c'):
+                    sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
+                    item['sun_center_diff'] = sun_center_offset
+                    item['sun_rad_diff'] = sun_radius_diff
+                else:
+                    item['sun_center_diff'] = "undefined"
+                    item['sun_rad_diff'] = "undefined"
             else:
                 item['sun_center_diff'] = "No Sun in ground truth"
                 item['sun_rad_diff'] = "No Sun in ground truth"
 
-            if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
+            if tokens[1].startswith('c') and truth_positions[img_name]['sun'] is not None:
                 pos_sum += (sun_center_offset + sun_radius_diff)
                 pos_count += 1
-            if tokens[2] is not None and truth_positions[img_name]['moon'] is not None:
+            if tokens[2].startswith('c') and truth_positions[img_name]['moon'] is not None:
                 pos_sum += (moon_center_offset + moon_radius_diff)
                 pos_count += 1
                 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -434,7 +434,7 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         if tokens[2].startswith('c'):
             item['found_moon'] = literal_eval(tokens[2][1:])
         else:
-            item['found_sun'] = "undefined"
+            item['found_moon'] = "undefined"
             
         if truth_file is not None and img_name in truth_positions:
  

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -470,8 +470,8 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
 
         metadata_items.append(item)
     
-    time_score /= time_count
-    pos_score = pos_sum / pos_count
+    time_score = time_score / time_count if time_count != 0 else None
+    pos_score = pos_sum / pos_count if pos_count != 0 else None
 
     return metadata_items, time_score, pos_score
 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -69,11 +69,11 @@ HTML = """
         var row1_result = row1_cell.innerHTML.split("<br>");
         var row2_result = row2_cell.innerHTML.split("<br>");
 
-        var row1_val = row1_result[1];
-        row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[4]));
+        var row1_val = row1_result[4];
+        row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[7]));
 
-        var row2_val = row2_result[1];
-        row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[4]));
+        var row2_val = row2_result[4];
+        row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[7]));
 
         if (row1_val < row2_val) {
             return -1;
@@ -93,18 +93,18 @@ HTML = """
         var row1_result = row1_cell.innerHTML.split("<br>");
         var row2_result = row2_cell.innerHTML.split("<br>");
 
-        var row1_val = row1_result[1];
+        var row1_val = row1_result[4];
         if (row1_val.toLowerCase().includes("no moon")) {
             row1_val = 10000;
         } else {
-            row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[4]));
+            row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[7]));
         }
 
-        var row2_val = row2_result[1];
+        var row2_val = row2_result[4];
         if (row2_val.toLowerCase().includes("no moon")) {
             row2_val = 10000;
         } else {
-            row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[4]));
+            row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[7]));
         }
 
         if (row1_val < row2_val) {
@@ -239,12 +239,12 @@ HTML = """
 	                        </th>
 
 	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(2)" style="cursor: pointer;">
-		                        Sun Diff (px)
+		                        Sun Results
                                 <i id="sun_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="sun_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
 	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(3)" style="cursor: pointer;">
-		                        Moon Diff (px)
+		                        Moon Results
                                 <i id="moon_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="moon_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
@@ -268,15 +268,19 @@ HTML = """
 							    <img src="{{item.processed}}">
 						    </td>
 						    <td class="mdl-data-table__cell--non-numeric">
-							    Center offset: <br>{{item.sun_center_diff}}<br>
+						        Found circle (cx, cy, r): <br>{{item.found_sun}}<br>
                                 <br>
-                                Radius difference: <br>{{item.sun_rad_diff}}<br>
+							    Center offset (px): <br>{{item.sun_center_diff}}<br>
+                                <br>
+                                Radius difference (px): <br>{{item.sun_rad_diff}}<br>
 						    </td>
 						    <td class="mdl-data-table__cell--non-numeric">
                                 {{ item.no_moon }}
-							    Center offset: <br>{{item.moon_center_diff}}<br>
+                                Found circle (cx, cy, r): <br>{{item.found_moon}}<br>
                                 <br>
-                                Radius difference: <br>{{item.moon_rad_diff}}<br>
+							    Center offset (px): <br>{{item.moon_center_diff}}<br>
+                                <br>
+                                Radius difference (px): <br>{{item.moon_rad_diff}}<br>
 						    </td>
 						    <td class="mdl-data-table__cell--non-numeric">
 						        <ul>
@@ -342,8 +346,7 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
     for line in f.readlines():
         tokens = line.split('|')
         
-        path_tokens = tokens[0].split('/')
-        img_name = path_tokens[len(path_tokens) - 1]
+        img_name = os.path.basename(tokens[0])
 
         item = dict(
             image_name = img_name, 
@@ -368,7 +371,17 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
                 
         item['times'] = times
         item['comments'] = comments
-
+        
+        if tokens[1] is not None:
+            item['found_sun'] = literal_eval(tokens[1][1:])
+        else:
+            item['found_sun'] = "undefined"
+            
+        if tokens[2] is not None:
+            item['found_moon'] = literal_eval(tokens[2][1:])
+        else:
+            item['found_sun'] = "undefined"
+        
         if truth_positions[img_name]['moon'] is not None:
             moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
             item['moon_center_diff'] = moon_center_offset

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -436,32 +436,36 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         else:
             item['found_sun'] = "undefined"
             
-        if truth_file is not None:
-        
-            try:
-                if truth_positions[img_name]['moon'] is not None:
-                    moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
-                    item['moon_center_diff'] = moon_center_offset
-                    item['moon_rad_diff'] = moon_radius_diff
-                else:
-                    item['moon_center_diff'] = "No Moon in ground truth"
-                    item['moon_rad_diff'] = "No Moon in ground truth"
+        if truth_file is not None and img_name in truth_positions:
+ 
+            if truth_positions[img_name]['moon'] is not None:
+                moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
+                item['moon_center_diff'] = moon_center_offset
+                item['moon_rad_diff'] = moon_radius_diff
+            else:
+                item['moon_center_diff'] = "No Moon in ground truth"
+                item['moon_rad_diff'] = "No Moon in ground truth"
 
+            if truth_positions[img_name]['sun'] is not None:
                 sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
-
                 item['sun_center_diff'] = sun_center_offset
                 item['sun_rad_diff'] = sun_radius_diff
+            else:
+                item['sun_center_diff'] = "No Sun in ground truth"
+                item['sun_rad_diff'] = "No Sun in ground truth"
+
+            # sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
+
+            # item['sun_center_diff'] = sun_center_offset
+            # item['sun_rad_diff'] = sun_radius_diff
                 
-                if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
-                    pos_sum += (sun_center_offset + sun_radius_diff)
-                    pos_count += 1
-                if tokens[2] is not None and truth_positions[img_name]['moon'] is not None:
-                    pos_sum += (moon_center_offset + moon_radius_diff)
-                    pos_count += 1
+            if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
+                pos_sum += (sun_center_offset + sun_radius_diff)
+                pos_count += 1
+            if tokens[2] is not None and truth_positions[img_name]['moon'] is not None:
+                pos_sum += (moon_center_offset + moon_radius_diff)
+                pos_count += 1
                 
-            except KeyError:
-                pass
-            
         else:
             item['moon_center_diff'] = "No ground truth"
             item['moon_rad_diff'] = "No ground truth"

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -454,11 +454,6 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
                 item['sun_center_diff'] = "No Sun in ground truth"
                 item['sun_rad_diff'] = "No Sun in ground truth"
 
-            # sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
-
-            # item['sun_center_diff'] = sun_center_offset
-            # item['sun_rad_diff'] = sun_radius_diff
-                
             if tokens[1] is not None and truth_positions[img_name]['sun'] is not None:
                 pos_sum += (sun_center_offset + sun_radius_diff)
                 pos_count += 1

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -12,6 +12,7 @@ TRUTH_FILE = "image_data.txt"
 
 HTML = """
 <script defer src="https://code.getmdl.io/1.2.1/material.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
@@ -46,6 +47,15 @@ HTML = """
 
     var prev_col_name = " ";
     var ascending = true;
+    
+    function toggle_circles(element) {
+        $(element).next().slideToggle();
+        if(element.innerText == "expand circles") {
+            element.innerHTML = "collapse circles"
+        } else if(element.innerText == "collapse circles") {
+            element.innerHTML = "expand circles"
+        }
+    }
 
     function hide_all_arrows() {
 
@@ -253,6 +263,9 @@ HTML = """
                                 <i id="times_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="times_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
+	                        <th class="mdl-data-table__cell--non-numeric">
+		                        All Found Circles
+	                        </th>
 		                    <th class="mdl-data-table__cell--non-numeric">
 		                        Comments
 	                        </th>
@@ -288,6 +301,16 @@ HTML = """
 						            <li> {{ time }} </li>
 						        {% endfor %}
 						        </ul>
+						    </td>
+						    <td class="mdl-data-table__cell--non-numeric">
+						        <span id="exp_collapse" style="cursor: pointer;" onclick="toggle_circles(this)"> expand circles </span>
+						        <div style="display: none;">
+						            <ul>
+							        {% for circle in item.circles %}
+							            <li> {{ circle }} </li>
+							        {% endfor %}
+							        </ul>
+						        </div>
 						    </td>
 						    <td class="mdl-data-table__cell--non-numeric">
 							    <ul>
@@ -357,12 +380,13 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         times = []
         comments = []
         token_count = 0
+        circles = []
         for token in tokens:
             if token.startswith('t'):
                 tup = literal_eval(token[1:])
                 times.append(tup[0] + ":\t" + str(tup[1]))
             elif token.startswith('c'):
-                None
+                circles.append(literal_eval(token[1:]))
             elif token_count > 1 and token != "\n":
                 comments.append(token)
             else:
@@ -371,6 +395,7 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
                 
         item['times'] = times
         item['comments'] = comments
+        item['circles'] = circles
         
         if tokens[1] is not None:
             item['found_sun'] = literal_eval(tokens[1][1:])

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -333,7 +333,7 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
 
         position = dict(sun = literal_eval(tokens[2]), moon = literal_eval(tokens[3]))
 
-        truth_positions[os.path.join(processed_path, tokens[0])] = position
+        truth_positions[tokens[0]] = position
     
     f = open(os.path.join(processed_path, "metadata.txt"), 'r')
 
@@ -369,21 +369,18 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
         item['times'] = times
         item['comments'] = comments
 
-        if truth_positions[tokens[0]]['moon'] is not None:
-            moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[tokens[0]]['moon'])
+        if truth_positions[img_name]['moon'] is not None:
+            moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
             item['moon_center_diff'] = moon_center_offset
             item['moon_rad_diff'] = moon_radius_diff
         else:
             item['moon_center_diff'] = "No Moon in ground truth"
             item['moon_rad_diff'] = "No Moon in ground truth"
 
-        sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[tokens[0]]['sun'])
+        sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
 
         item['sun_center_diff'] = sun_center_offset
         item['sun_rad_diff'] = sun_radius_diff
-
-        if tokens[5] == "1":
-            item['comments'] = '<br>'.join(item.strip() for item in tokens[6].split(';'))
 
         metadata_items.append(item)
 
@@ -420,7 +417,7 @@ def main():
     html_path = build_html_doc(original_dir, processed_dir, original_bucket, processed_bucket, converter)
     html_path = converter.get_run_specific_filename(html_path)
 
-    converter.commit(processed_dir)
+    #converter.commit(processed_dir)
 
     print('WEB_URL:{}'.format(util.gcs_url(html_path, processed_bucket)))
 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -53,9 +53,10 @@ HTML = """
 <script>
 
     var COLUMN_CHOICES = {
-        SUN : 2,
-        MOON : 3,
-        TIMES : 4
+        ORIGINAL_IMG: 0,
+        SUN:          2,
+        MOON:         3,
+        TIMES:        4,
     };
 
     var prev_col_name = " ";
@@ -72,6 +73,9 @@ HTML = """
 
     function hide_all_arrows() {
 
+        document.getElementById("original_img_up").style.display = "none";
+        document.getElementById("original_img_down").style.display = "none";
+
         document.getElementById("sun_diff_up").style.display = "none";
         document.getElementById("sun_diff_down").style.display = "none";
 
@@ -80,7 +84,6 @@ HTML = """
 
         document.getElementById("times_up").style.display = "none";
         document.getElementById("times_down").style.display = "none";
-
     }
 
     function sun_diff_comparator(row1, row2) {
@@ -171,6 +174,24 @@ HTML = """
         return 0;
     }
 
+    function original_img_comparator(row1, row2) {
+        var col_val = 0;
+
+        var row1_cell = row1.getElementsByTagName("td")[col_val];
+        var row2_cell = row2.getElementsByTagName("td")[col_val];
+
+        var row1_val  = row1.getElementsByTagName("img")[0].getAttribute("src");
+        var row2_val  = row2.getElementsByTagName("img")[0].getAttribute("src");
+
+        if (row1_val < row2_val) {
+            return -1;
+        }
+        if (row1_val > row2_val) {
+            return 1;
+        }
+        return 0;
+    }
+
     function sort_table(n) {
 
         var table = document.getElementById("eclipse_data_table");
@@ -181,6 +202,10 @@ HTML = """
         var start = performance.now();
 
         switch(n) {
+            case COLUMN_CHOICES.ORIGINAL_IMG:
+                var col_name = "original_img";
+                row_array.sort(original_img_comparator);
+                break;
             case COLUMN_CHOICES.SUN:
                 var col_name = "sun_diff";
                 row_array.sort(sun_diff_comparator);
@@ -258,13 +283,14 @@ HTML = """
                 <table id="eclipse_data_table" class="mdl-data-table mdl-js-data-table">
                     <thead>
                         <tr>
-	                        <th class="mdl-data-table__cell--non-numeric">
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(COLUMN_CHOICES.ORIGINAL_IMG)" style="cursor: pointer;">
 		                        Original
+                                <i id="original_img_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
+                                <i id="original_img_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
 	                        </th>
 	                        <th class="mdl-data-table__cell--non-numeric">
 		                        Processed
 	                        </th>
-
 	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(COLUMN_CHOICES.SUN)" style="cursor: pointer;">
 		                        Sun Results
                                 <i id="sun_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -41,6 +41,13 @@ HTML = """
 			max-width: 300px;
 			max-height: 300px;
 		}
+        .mdl-layout {
+            width: auto;
+            overflow-x: scroll;
+        }
+        .mdl-layout__content {
+            overflow-x: scroll;
+        }
 	</style>
 
 <script>

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -41,184 +41,167 @@ HTML = """
 		}
 	</style>
 
-	<script>
+<script>
 
-        var prev_col_name = " ";
-        var ascending = true;
+    var prev_col_name = " ";
+    var ascending = true;
 
-        function hide_all_arrows() {
+    function hide_all_arrows() {
 
-            document.getElementById("sun_diff_up").style.display = "none";
-            document.getElementById("sun_diff_down").style.display = "none";
+        document.getElementById("sun_diff_up").style.display = "none";
+        document.getElementById("sun_diff_down").style.display = "none";
 
-            document.getElementById("moon_diff_up").style.display = "none";
-            document.getElementById("moon_diff_down").style.display = "none";
+        document.getElementById("moon_diff_up").style.display = "none";
+        document.getElementById("moon_diff_down").style.display = "none";
 
-            document.getElementById("pre_proc_up").style.display = "none";
-            document.getElementById("pre_proc_down").style.display = "none";
+        document.getElementById("times_up").style.display = "none";
+        document.getElementById("times_down").style.display = "none";
 
-            document.getElementById("hough_up").style.display = "none";
-            document.getElementById("hough_down").style.display = "none";
+    }
 
+    function sun_diff_comparator(row1, row2) {
+        var col_val = 2;
+
+        var row1_cell = row1.getElementsByTagName("td")[col_val];
+        var row2_cell = row2.getElementsByTagName("td")[col_val];
+
+        var row1_result = row1_cell.innerHTML.split("<br>");
+        var row2_result = row2_cell.innerHTML.split("<br>");
+
+        var row1_val = row1_result[1];
+        row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[4]));
+
+        var row2_val = row2_result[1];
+        row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[4]));
+
+        if (row1_val < row2_val) {
+            return -1;
         }
+        if (row1_val > row2_val) {
+            return 1;
+        }
+        return 0;
+    }
 
-        function sun_diff_comparator(row1, row2) {
-            var col_val = 2;
+    function moon_diff_comparator(row1, row2) {
+        var col_val = 3;
 
-            var row1_cell = row1.getElementsByTagName("td")[col_val];
-            var row2_cell = row2.getElementsByTagName("td")[col_val];
+        var row1_cell = row1.getElementsByTagName("td")[col_val];
+        var row2_cell = row2.getElementsByTagName("td")[col_val];
 
-            var row1_result = row1_cell.innerHTML.split("<br>");
-            var row2_result = row2_cell.innerHTML.split("<br>");
+        var row1_result = row1_cell.innerHTML.split("<br>");
+        var row2_result = row2_cell.innerHTML.split("<br>");
 
-            var row1_val = row1_result[1];
+        var row1_val = row1_result[1];
+        if (row1_val.toLowerCase().includes("no moon")) {
+            row1_val = 10000;
+        } else {
             row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[4]));
+        }
 
-            var row2_val = row2_result[1];
+        var row2_val = row2_result[1];
+        if (row2_val.toLowerCase().includes("no moon")) {
+            row2_val = 10000;
+        } else {
             row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[4]));
-
-            if (row1_val < row2_val) {
-                return -1;
-            }
-            if (row1_val > row2_val) {
-                return 1;
-            }
-            return 0;
         }
 
-        function moon_diff_comparator(row1, row2) {
-            var col_val = 3;
+        if (row1_val < row2_val) {
+            return -1;
+        }
+        if (row1_val > row2_val) {
+            return 1;
+        }
+        return 0;
+    }
 
-            var row1_cell = row1.getElementsByTagName("td")[col_val];
-            var row2_cell = row2.getElementsByTagName("td")[col_val];
+    function times_comparator(row1, row2) {
+        var col_val = 4;
 
-            var row1_result = row1_cell.innerHTML.split("<br>");
-            var row2_result = row2_cell.innerHTML.split("<br>");
+        var row1_cell = row1.getElementsByTagName("td")[col_val];
+        var row2_cell = row2.getElementsByTagName("td")[col_val];
 
-            var row1_val = row1_result[1];
-            if (row1_val.toLowerCase().includes("no moon")) {
-                row1_val = 10000;
-            } else {
-                row1_val = parseFloat(row1_val) + Math.abs(parseFloat(row1_result[4]));
+        var row1_list = row1_cell.getElementsByTagName("ul")[0];
+        var row2_list = row2_cell.getElementsByTagName("ul")[0];
+
+        var row1_val = 0.0;
+        for (element in row1_list.children) {
+            if (typeof(row1_list.children[element].innerHTML) != 'undefined') {
+                row1_val += parseFloat(row1_list.children[element].innerHTML.split(":")[1]);
             }
-
-            var row2_val = row2_result[1];
-            if (row2_val.toLowerCase().includes("no moon")) {
-                row2_val = 10000;
-            } else {
-                row2_val = parseFloat(row2_val) + Math.abs(parseFloat(row2_result[4]));
-            }
-
-            if (row1_val < row2_val) {
-                return -1;
-            }
-            if (row1_val > row2_val) {
-                return 1;
-            }
-            return 0;
         }
 
-        function pre_proc_comparator(row1, row2) {
-            var col_val = 4;
-
-            var row1_cell = row1.getElementsByTagName("td")[col_val];
-            var row2_cell = row2.getElementsByTagName("td")[col_val];
-
-            var row1_result = row1_cell.innerHTML.split(" ");
-            var row2_result = row2_cell.innerHTML.split(" ");
-
-            var row1_val = row1_result[4];
-            var row2_val = row2_result[4];
-
-            if (row1_val < row2_val) {
-                return -1;
+        var row2_val = 0.0;
+        for (element in row2_list.children) {
+            if (typeof(row2_list.children[element].innerHTML) != 'undefined') {
+                row2_val += parseFloat(row2_list.children[element].innerHTML.split(":")[1]);
             }
-            if (row1_val > row2_val) {
-                return 1;
-            }
-            return 0;
         }
 
-        function hough_comparator(row1, row2) {
-            var col_val = 5;
+        if (row1_val < row2_val) {
+            return -1;
+        }
+        if (row1_val > row2_val) {
+            return 1;
+        }
+        return 0;
+    }
 
-            row1_cell = row1.getElementsByTagName("td")[col_val];
-            row2_cell = row2.getElementsByTagName("td")[col_val];
+    function sort_table(n) {
 
-            var row1_result = row1_cell.innerHTML.split(" ");
-            var row2_result = row2_cell.innerHTML.split(" ");
+        var table = document.getElementById("eclipse_data_table");
+        var table_body = document.getElementById("eclipse_data_table_body");
 
-            var row1_val = row1_result[4];
-            var row2_val = row2_result[4];
+        var row_array = Array.prototype.slice.call(table_body.children);
 
-            if (row1_val < row2_val) {
-                return -1;
-            }
-            if (row1_val > row2_val) {
-                return 1;
-            }
-            return 0;
+        var start = performance.now();
+
+        switch(n) {
+            case 2:
+                var col_name = "sun_diff";
+                row_array.sort(sun_diff_comparator);
+                break;
+            case 3:
+                var col_name = "moon_diff";
+                row_array.sort(moon_diff_comparator);
+                break;
+            case 4:
+                var col_name = "times";
+                row_array.sort(times_comparator);
+                break;
+            default:
+                console.log("error this isn't possible");
         }
 
-        function sort_table(n) {
+        if(prev_col_name == col_name) {
+            ascending = !ascending;
+        } else {
+            ascending = true;
+        }
 
-            var table = document.getElementById("eclipse_data_table");
-            var table_body = document.getElementById("eclipse_data_table_body");
-
-            var row_array = Array.prototype.slice.call(table_body.children);
-
-            var start = performance.now();
-
-            switch(n) {
-                case 2:
-                    var col_name = "sun_diff";
-                    row_array.sort(sun_diff_comparator);
-                    break;
-                case 3:
-                    var col_name = "moon_diff";
-                    row_array.sort(moon_diff_comparator);
-                    break;
-                case 4:
-                    var col_name = "pre_proc";
-                    row_array.sort(pre_proc_comparator);
-                    break;
-                case 5:
-                    var col_name = "hough";
-                    row_array.sort(hough_comparator);
-                    break;
-                defult:
-                    console.log("error this isn't possible");
+        if (ascending) {
+            for (var i = 0; i < row_array.length; i++) {
+                table.children[1].appendChild(row_array[i]);
             }
-
-            if(prev_col_name == col_name) {
-                ascending = !ascending;
-            } else {
-                ascending = true;
+            var arrow_direction = "up";
+        } else {
+            for (var i = row_array.length -1; i > -1; i--) {
+                table.children[1].appendChild(row_array[i]);
             }
+            var arrow_direction = "down";
+        }
 
-            if (ascending) {
-                for (var i = 0; i < row_array.length; i++) {
-                    table.children[1].appendChild(row_array[i]);
-                }
-                var arrow_direction = "up";
-            } else {
-                for (var i = row_array.length -1; i > -1; i--) {
-                    table.children[1].appendChild(row_array[i]);
-                }
-                var arrow_direction = "down";
-            }
+        hide_all_arrows();
+        document.getElementById(col_name + "_" + arrow_direction).style.display = "";
 
-            hide_all_arrows();
-            document.getElementById(col_name + "_" + arrow_direction).style.display = "";
+        var end = performance.now();
+        var time = end - start;
+        console.log('Execution time: ' + time);
 
-            var end = performance.now();
-            var time = end - start;
-            console.log('Execution time: ' + time);
+        prev_col_name = col_name;
+    }
 
-            prev_col_name = col_name;
-        }       
-
-	</script>
+</script>
 </head>
 <body>
 
@@ -245,33 +228,35 @@ HTML = """
                 <h3>Output Table</h3>
 
                 <table id="eclipse_data_table" class="mdl-data-table mdl-js-data-table">
-				    <thead>
-					    <tr>
-						    <th class="mdl-data-table__cell--non-numeric">
-							    Original
-						    </th>
-						    <th class="mdl-data-table__cell--non-numeric">
-							    Processed
-						    </th>
+                    <thead>
+                        <tr>
+	                        <th class="mdl-data-table__cell--non-numeric">
+		                        Original
+	                        </th>
+	                        <th class="mdl-data-table__cell--non-numeric">
+		                        Processed
+	                        </th>
 
-						    <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(2)" style="cursor: pointer;">
-							    Sun Diff (px)
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(2)" style="cursor: pointer;">
+		                        Sun Diff (px)
                                 <i id="sun_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="sun_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
-						    </th>
-						    <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(3)" style="cursor: pointer;">
-							    Moon Diff (px)
+	                        </th>
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(3)" style="cursor: pointer;">
+		                        Moon Diff (px)
                                 <i id="moon_diff_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
                                 <i id="moon_diff_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
-						    </th>
-						    <th class="mdl-data-table__cell--non-numeric">
-							    Running times (secs)
-						    </th>
-                    		<th class="mdl-data-table__cell--non-numeric">
-							    Comments
-						    </th>
-					    </tr>
-					</thead>
+	                        </th>
+	                        <th class="mdl-data-table__cell--non-numeric" onclick="sort_table(4)" style="cursor: pointer;">
+		                        Running times (secs)
+                                <i id="times_down" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_down</i>
+                                <i id="times_up" style="position: absolute; display: none;" class="material-icons">keyboard_arrow_up</i>
+	                        </th>
+		                    <th class="mdl-data-table__cell--non-numeric">
+		                        Comments
+	                        </th>
+                        </tr>
+                    </thead>
 				    <tbody id="eclipse_data_table_body">
                     {% for item in items %}
 					    <tr>

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -358,15 +358,20 @@ def euclidean_distance(circle1, circle2):
 
 def read_metadata(original_path, processed_path, original_bucket, processed_bucket, converter):
 
-    truth_file = open(os.path.join(original_path, TRUTH_FILE), 'r')
+    try: 
+        truth_file = open(os.path.join(original_path, TRUTH_FILE), 'r')
+    except FileNotFoundError:
+        truth_file = None
+        
+    if truth_file is not None:
 
-    truth_positions = {}
-    for line in truth_file:
-        tokens = line.split('|')
+        truth_positions = {}
+        for line in truth_file:
+            tokens = line.split('|')
 
-        position = dict(sun = literal_eval(tokens[2]), moon = literal_eval(tokens[3]))
+            position = dict(sun = literal_eval(tokens[2]), moon = literal_eval(tokens[3]))
 
-        truth_positions[tokens[0]] = position
+            truth_positions[tokens[0]] = position
     
     f = open(os.path.join(processed_path, "metadata.txt"), 'r')
 
@@ -412,19 +417,28 @@ def read_metadata(original_path, processed_path, original_bucket, processed_buck
             item['found_moon'] = literal_eval(tokens[2][1:])
         else:
             item['found_sun'] = "undefined"
+            
+        if truth_file is not None:
         
-        if truth_positions[img_name]['moon'] is not None:
-            moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
-            item['moon_center_diff'] = moon_center_offset
-            item['moon_rad_diff'] = moon_radius_diff
+            if truth_positions[img_name]['moon'] is not None:
+                moon_center_offset, moon_radius_diff = calc_position_diff(literal_eval(tokens[2][1:]), truth_positions[img_name]['moon'])
+                item['moon_center_diff'] = moon_center_offset
+                item['moon_rad_diff'] = moon_radius_diff
+            else:
+                item['moon_center_diff'] = "No Moon in ground truth"
+                item['moon_rad_diff'] = "No Moon in ground truth"
+
+            sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
+
+            item['sun_center_diff'] = sun_center_offset
+            item['sun_rad_diff'] = sun_radius_diff
+            
         else:
-            item['moon_center_diff'] = "No Moon in ground truth"
-            item['moon_rad_diff'] = "No Moon in ground truth"
-
-        sun_center_offset, sun_radius_diff = calc_position_diff(literal_eval(tokens[1][1:]), truth_positions[img_name]['sun'])
-
-        item['sun_center_diff'] = sun_center_offset
-        item['sun_rad_diff'] = sun_radius_diff
+            item['moon_center_diff'] = "No ground truth"
+            item['moon_rad_diff'] = "No ground truth"
+            
+            item['sun_center_diff'] = "No ground truth"
+            item['sun_rad_diff'] = "No ground truth"
 
         metadata_items.append(item)
 

--- a/tools/run_imgproc_test/image_proc_output.py
+++ b/tools/run_imgproc_test/image_proc_output.py
@@ -1,10 +1,11 @@
-import subprocess
 from jinja2 import Environment, Template
 import time
 import os
 import sys
 from ast import literal_eval
 import math
+
+import util
 
 OUTPUT_FILE = "output.html"
 TRUTH_FILE = "image_data.txt"
@@ -390,8 +391,7 @@ def read_metadata(original_path, processed_path):
     
 def build_html_doc(original_path, processed_path):
 
-    #get all 40 characters of the commit hash
-    commit_hash = str(subprocess.check_output("git rev-parse HEAD", shell=True))[2:42]
+    commit_hash = util.current_git_hash_str()
 
     #set date/time for title
     date_time = time.strftime("%c", time.localtime())

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -1,19 +1,23 @@
 set "-e"
 
-if [ $# = 0 ]; then
-    echo "Usage: test image_dir [download]"
+if [ $# -lt 2 ]; then
+    echo "Usage: test working_dir src_gcs_bucket [download]"
     exit
 fi
 
+SRC_IMG_BUCKET=$2
+PROCESSED_BUCKET=eclipse_imgproc_output
+
 BASE_DIR=$(cd $1 && pwd)
-SRC_IMG_BUCKET=eclipse_image_ground_truth_dataset_renamed
 SRC_IMG_DIR=$BASE_DIR/$SRC_IMG_BUCKET
 SRC_IMG_FILE=$SRC_IMG_DIR/images.txt
 OUTPUT_DIR=$BASE_DIR/output
 
+TMP_FILE=$OUTPUT_DIR/__tmp_python_output
+
 if [ ! -d $SRC_IMG_DIR ]; then
     
-    if [ $2 = download ]; then
+    if [ $3 = download ]; then
         mkdir $SRC_IMG_DIR
         echo "Saving images from GCS to $SRC_IMG_DIR..."
         gsutil -m cp "gs://$SRC_IMG_BUCKET/*" $SRC_IMG_DIR
@@ -36,6 +40,12 @@ make
 ./pipeline $SRC_IMG_FILE batch $OUTPUT_DIR
 popd
 
-python3 image_proc_output.py $SRC_IMG_DIR $OUTPUT_DIR
-google-chrome $OUTPUT_DIR/output.html
- 
+# Create html output, rename image files
+python3 image_proc_output.py $SRC_IMG_DIR $OUTPUT_DIR $SRC_IMG_BUCKET $PROCESSED_BUCKET > $TMP_FILE
+
+# Upload processed image files, html file to GCS
+gsutil -m cp $OUTPUT_DIR/* gs://$PROCESSED_BUCKET
+
+# Output Web URL
+cat $TMP_FILE
+rm -f $TMP_FILE

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -51,7 +51,7 @@ make
 popd
 
 # Create html output, rename image files
-python3 image_proc_output.py $SRC_IMG_DIR $OUTPUT_DIR $SRC_IMG_BUCKET $PROCESSED_BUCKET > $TMP_FILE
+python3 image_proc_output.py $SRC_IMG_DIR $OUTPUT_DIR $SRC_IMG_BUCKET $PROCESSED_BUCKET $PIPELINE_FLAGS > $TMP_FILE
 
 # Upload processed image files, html file to GCS
 gsutil -m cp $OUTPUT_DIR/* gs://$PROCESSED_BUCKET

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -8,7 +8,7 @@ if [ $# -lt 2 ]; then
 fi
 
 if [ $# -gt 2 ]; then
-    if [ $# = 3 ] && [ $3 != download ]; then
+    if [ $# = 3 ] && [ "$3" != download ]; then
         PIPELINE_FLAGS=$3
     else
         PIPELINE_FLAGS=$4

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -15,6 +15,8 @@ if [ $# -gt 2 ]; then
     fi
 fi
 
+IMG_EXT="\.jpg\|\.JPG\|\.jpeg\|\.JPEG\|\.png\|\.PNG"
+
 SRC_IMG_BUCKET=$2
 PROCESSED_BUCKET=eclipse_imgproc_output
 
@@ -31,10 +33,7 @@ if [ ! -d $SRC_IMG_DIR ]; then
         mkdir $SRC_IMG_DIR
         echo "Saving images from GCS to $SRC_IMG_DIR..."
         gsutil -m cp "gs://$SRC_IMG_BUCKET/*" $SRC_IMG_DIR
-        cat $SRC_IMG_DIR/image_data.txt | cut -d "|" -f 1 > $SRC_IMG_FILE
-        python -c "open(\"$SRC_IMG_FILE\" + \"-tmp\", \"w\").writelines(\"$SRC_IMG_DIR/\" + l for l in open(\"$SRC_IMG_FILE\").readlines())"
-        rm -f $SRC_IMG_FILE
-        mv $SRC_IMG_FILE-tmp $SRC_IMG_FILE
+        find $SRC_IMG_DIR -maxdepth 1 | grep $IMG_EXT > $SRC_IMG_FILE
     else
         echo "Directory: $SRC_IMG_DIR not found."
         echo "Run with the optional download parameter to download images"

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -8,7 +8,7 @@ if [ $# -lt 2 ]; then
 fi
 
 if [ $# -gt 2 ]; then
-    if [ $# = 3 ]; then
+    if [ $# = 3 ] && [ $3 != download ]; then
         PIPELINE_FLAGS=$3
     else
         PIPELINE_FLAGS=$4

--- a/tools/run_imgproc_test/test
+++ b/tools/run_imgproc_test/test
@@ -1,8 +1,18 @@
+#!/bin/bash
+
 set "-e"
 
 if [ $# -lt 2 ]; then
-    echo "Usage: test working_dir src_gcs_bucket [download]"
+    echo 'Usage: ./test $WORKING_DIR $SRC_GCS_BUCKET [download] [$PIPELINE_FLAGS]'
     exit
+fi
+
+if [ $# -gt 2 ]; then
+    if [ $# = 3 ]; then
+        PIPELINE_FLAGS=$3
+    else
+        PIPELINE_FLAGS=$4
+    fi
 fi
 
 SRC_IMG_BUCKET=$2
@@ -13,7 +23,7 @@ SRC_IMG_DIR=$BASE_DIR/$SRC_IMG_BUCKET
 SRC_IMG_FILE=$SRC_IMG_DIR/images.txt
 OUTPUT_DIR=$BASE_DIR/output
 
-TMP_FILE=$OUTPUT_DIR/__tmp_python_output
+TMP_FILE=$BASE_DIR/__tmp_python_output
 
 if [ ! -d $SRC_IMG_DIR ]; then
     
@@ -37,7 +47,7 @@ mkdir $OUTPUT_DIR
 pushd ../../src/imgproc/cpp
 make clean
 make
-./pipeline $SRC_IMG_FILE batch $OUTPUT_DIR
+./pipeline --images_file=$SRC_IMG_FILE --mode=batch --output_dir=$OUTPUT_DIR $PIPELINE_FLAGS
 popd
 
 # Create html output, rename image files

--- a/tools/run_imgproc_test/util.py
+++ b/tools/run_imgproc_test/util.py
@@ -1,0 +1,5 @@
+import subprocess
+
+def current_git_hash_str():
+    return subprocess.check_output('git rev-parse HEAD', shell=True).decode('utf-8').strip()
+

--- a/tools/run_imgproc_test/util.py
+++ b/tools/run_imgproc_test/util.py
@@ -1,5 +1,48 @@
+import datetime
+from getpass import getuser
+import os
 import subprocess
 
+
+GCS_URL_FMT = 'https://storage.googleapis.com/{}/{}'
+
+
 def current_git_hash_str():
-    return subprocess.check_output('git rev-parse HEAD', shell=True).decode('utf-8').strip()
+    return subprocess.check_output('git rev-parse --short HEAD', shell=True).decode('utf-8').strip()
+
+
+def gcs_url(fname, bucket):
+    return GCS_URL_FMT.format(bucket, fname)
+
+
+class FilenameConverter(object):
+
+    def __init__(self):
+        self.mappings = dict()
+        self.datetime = datetime.datetime.now()
+        self.time_str = self.datetime.strftime('%Y_%m_%d-%H_%M_%S')
+        self.git_hash = current_git_hash_str()
+        self.user = getuser()
+
+    def get_run_specific_filename(self, current_filename):
+        # Just in case
+        current_filename = os.path.basename(current_filename)
+
+        # Extract file extension
+        name, ext = os.path.splitext(current_filename)
+
+        # Assemble run specific filename
+        name = '-'.join((name, self.git_hash, self.user, self.time_str))
+        new_fname = name + ext
+
+        # Save old -> new filename mapping
+        self.mappings[current_filename] = new_fname
+
+        return new_fname
+
+    def commit(self, dir_path):
+        for f in self.mappings:
+            old = os.path.join(dir_path, f)
+            new = os.path.join(dir_path, self.mappings[f])
+            os.rename(old, new)
 


### PR DESCRIPTION
- `run_imgproc_test` now uploads results files to Google Cloud Storage
- `run_imgproc_test` now accepts a Google Cloud Storage bucket as a parameter. Image files to process are downloaded from this bucket
- `image_proc_output.py` is now tolerant to lack of ground truth data
- Image processor pipeline now uses gflags for command line argument parsing and supports passing hough params from the command line