### PR TITLE
Train logistic regression on VGG fully connected layer output

### DIFF
--- a/src/classification/README.md
+++ b/src/classification/README.md
@@ -1,10 +1,66 @@
 # Totality Image Classification
 
+***Beware: This is research quality code***
 
 ## Dependencies:
 
 - Python3
 - Keras
+
+
+## `classification_pipeline.py`
+
+### Required files
+
+- Labeled data JSON file
+  - A JSON file with a top level dictionary where the keys are Google Cloud Storage
+    URLs. Each key in this dictionary must have another dictionary associated with
+    it. These dictionaries must have a `'classification'` key that points to the
+    image classification, either `'TOTALITY'` or some other string, which will be treated
+    as non-totality. Note: the labeled data json file described above will work here.
+- Image files
+  - All images referenced the labeled data JSON file
+    must be saved in the same directory with their filenames
+    being the same as the basename of the files referenced in
+
+### Arguments
+
+- `--download`
+  - Optional flag. If specified, images will be downloaded from Google Cloud Storage
+    using gsutil.
+- `--img-dir`
+  - Optional. Directory where images live / are to be downloaded to. Default `./img/`.
+- `--label-file`
+  - Optional. Labeled data JSON file described above. Default `labled_data.json`
+
+### To Run
+
+```bash
+$ mkdir img
+$
+$ python3 classification_pipeline.py --img-dir=img --download --label-file=labeled_data.json
+```
+
+### Current Model Description
+
+This image classification application is composed of a two stage pipeline. The first stage
+runs the images through VGG19, pre-trained on imagenet. The output of this stage is not the
+file 1000-dimensional softmax output from VGG19, but instead the 4096-dimensional output from
+the file fully connected layer that feeds into the final softmax.
+
+This output is then passed to the second stage of the pipeline, which trains a simple, single
+layer logistic regression classifier on the outputs from stage 1. This classifier outputs a
+one-hot vector encoding an input as being of either totality, or non-totality. This stage
+performs 10 fold cross validation training, and then runs the entire image dataset through
+a new network where the weights are set to the average of the weights from the previous 10
+training steps.
+
+**Latest metrics**
+
+Results for averaged model on all images:
+- Accuracy: 0.9694
+- False positive rate: 0.0041
+- Acceptance ratio: 1.0
 
 
 ## `logistic_reg.py`

--- a/src/classification/classification_pipeline.py
+++ b/src/classification/classification_pipeline.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+
+import numpy as np
+from keras import backend as K
+
+from image_data import ImageDataKFold
+from image_data import ImageDataNP
+from logistic_reg import train_and_evaluate as train_and_eval_lr
+from utils import download_images
+from utils import get_vgg
+
+
+def main():
+    parser = argparse.ArgumentParser(description='A test')
+    parser.add_argument('--download', default=False, action='store_true')
+    parser.add_argument('--img-dir', type=str, default='img')
+    parser.add_argument('--label-file', type=str, default='labeled_data.json')
+    args = parser.parse_args()
+
+    if args.download:
+        with open(args.label_file) as f:
+            download_images(args.img_dir, list(json.load(f).keys()))
+
+    # VGG Phase
+    print('Collecting dataset...')
+    dataset = ImageDataNP(args.img_dir, labeled_data_file=args.label_file, train_ratio=1.0, squash=True)
+    x_train, y_train = dataset.get_train()
+
+    vgg = get_vgg('VGG19', weights='imagenet', classes=1000)
+    inp = vgg.input
+    out = vgg.get_layer(name='fc2').output
+    functor = K.function([inp], [out])
+
+    vgg_relu_out = list()
+    batch_size=32
+    start, end = 0, 0
+    print('Classifying images...')
+    for i in range(int((x_train.shape[0] + batch_size - 1) / batch_size)):
+        end = min((i + 1) * batch_size, x_train.shape[0])
+        print('Batch {}, images[{}:{}]'.format(i, start, end))
+
+        vecs = functor([x_train[start:end]])
+        vgg_relu_out.extend(vecs[0])
+
+        # Update start index
+        start = end
+
+    # Logistic Regression Phase
+    kfold_dataset = ImageDataKFold(nfolds=10, custom_data=(np.array(vgg_relu_out), y_train))
+    train_and_eval_lr(kfold_dataset)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/src/classification/utils.py
+++ b/src/classification/utils.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+
+from keras.applications.vgg16 import VGG16
+from keras.applications.vgg19 import VGG19
+from keras.layers import Dense
+from keras.models import Sequential
+
+
+def download_images(img_dir, img_uris):
+    """
+    Downloads images to <img_dir>/images.txt.
+    img_uris is a list of Google Cloud Storage uris.
+    """
+    if not os.path.isdir(img_dir):
+        os.mkdir(img_dir)
+
+    with open(os.path.join(img_dir, 'images.txt'), 'w+') as f:
+        f.write('\n'.join(img_uris))
+        f.seek(0)
+        subprocess.run(['gsutil', '-m', 'cp', '-I', img_dir], stdin=f)
+
+
+def get_vgg(name, include_top=True, weights=None, classes=2):
+    """
+    Returns VGG16/19 model, (depending on cls parameter)
+    """
+    if name == 'VGG16':
+        cls = VGG16
+    elif name == 'VGG19':
+        cls = VGG19
+
+    model = cls(include_top=include_top, input_shape=(224, 224, 3), weights=weights, classes=classes)
+    model.compile(loss='mse', optimizer='rmsprop')
+
+    return model
+
+
+def get_lr(in_dim, out_dim):
+    """
+    Returns simple one layer logistic regression model
+    """
+    model = Sequential()
+    model.add(Dense(out_dim, input_dim=in_dim))
+    model.compile(optimizer='rmsprop', loss='mse', metrics=['accuracy'])
+    return model
+


### PR DESCRIPTION
This makes the totality classification *totality* work! Currently achieving 96-97% classification accuracy.

This PR adds a 2 stage classification pipeline application. The first stage runs the images through VGG19, pre-trained on imagenet. The output of this stage is not the file 1000-dimensional softmax output from VGG19, but instead the 4096-dimensional output from the file fully connected layer that feeds into the final softmax (`'fc2'`).

This output is then passed to the second stage of the pipeline, which trains a simple, single layer logistic regression classifier on the outputs from stage 1. This classifier outputs a one-hot vector encoding an input as being of either totality, or non-totality. This stage performs 10 fold cross validation training, and then runs the entire image dataset through a new network where the weights are set to the average of the weights from the previous 10 training steps.